### PR TITLE
negative numbers should be uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Examples of correct code for this rule:
 
 const FOO = 'bar';
 const FOO = 42;
+const FOO = -42;
 
 const foo = ['bar', 42];
 const foo = {bar: 42, baz: 'qux'};

--- a/lib/rules/uppercase.js
+++ b/lib/rules/uppercase.js
@@ -1,5 +1,13 @@
 const msg = require('../message');
 
+/**
+ * @function isNegativeLiteral
+ * @return {bool} Whether the node is a negative literal.
+ */
+const isNegativeLiteral = init => init.type === 'UnaryExpression'
+      && init.operator === '-'
+      && init.argument.type === 'Literal';
+
 module.exports = {
     create: context => {
         return {
@@ -15,13 +23,15 @@ module.exports = {
                         const nameUpper = name ? name === name.toUpperCase() : false;
                         // return true if const type is literal
                         const initTypeLiteral = init ? init.type === 'Literal' : false;
+                        // return true if const is a negative literal
+                        const initTypeNegativeLiteral = init ? isNegativeLiteral(init) : false;
                         // return true if const using for require
                         const calleeRequire = init && init.callee ? init.callee.name === 'require' : false;
 
-                        if (initTypeLiteral && !nameUpper) {
+                        if ((initTypeLiteral || initTypeNegativeLiteral) && !nameUpper) {
                             context.report(node, msg.upper);
 
-                        } else if (!initTypeLiteral && nameUpper && !calleeRequire) {
+                        } else if (!(initTypeLiteral || initTypeNegativeLiteral) && nameUpper && !calleeRequire) {
                             context.report(node, msg.lower);
                         }
 

--- a/tests/uppercase.js
+++ b/tests/uppercase.js
@@ -21,6 +21,10 @@ ruleTester.run('const-uppercase', rule, {
             errors: [{TYPE, message: msg.upper}]
         },
         {
+            code: "const foo = -42",
+            errors: [{TYPE, message: msg.upper}]
+        },
+        {
             code: "const FOO = []",
             errors: [{TYPE, message: msg.lower}]
         },
@@ -146,6 +150,7 @@ ruleTester.run('const-uppercase', rule, {
         "const FOO = require('bar')",
         "const FOO = 'bar'",
         "const FOO = 42",
+        "const FOO = -42",
         "const foo = []",
         "const foo = ['bar', 42]",
         "const foo = {}",


### PR DESCRIPTION
Fixes #3.
It also enforces `const FOO = -'42'` whether or not it makes sense to write something like this.